### PR TITLE
Added package auto-discovery functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ composer require razorpay/slack-laravel
 
 Then [create an incoming webhook](https://my.slack.com/services/new/incoming-webhook) for each Slack team you'd like to send messages to. You'll need the webhook URL(s) in order to configure this package.
 
+## Laravel 5.5+
+
+If using Laravel version 5.5 or higher, this package will be automatically discovered by the Framework. No need to register the provider or Alias! Just run `php artisan vendor:publish` to publish the config file to `config/slack.php`.
+
 ## Laravel 5
+
+If you are using Laravel between 5.0 and 5.4, you will need to register the provider and alias as usual.
 
 Add the `Razorpay\Slack\Laravel\ServiceProvider` provider to the `providers` array in `config/app.php`:
 

--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,15 @@
             "Razorpay\\Slack\\Laravel\\": "src/"
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Razorpay\\Slack\\Laravel\\ServiceProviderLaravel5"
+            ],
+            "aliases": [
+                "Razorpay\\Slack\\Laravel\\Facade"
+            ]
+        }
+    },
     "minimum-stability": "stable"
 }

--- a/src/ServiceProviderLaravel5.php
+++ b/src/ServiceProviderLaravel5.php
@@ -15,7 +15,7 @@ class ServiceProviderLaravel5 extends \Illuminate\Support\ServiceProvider
    */
     public function boot()
     {
-        $this->publishes([__DIR__ . '/config/config.php' => config_path('slack.php')]);
+        $this->publishes([__DIR__ . '/config/config.php' => config_path('slack.php')], 'slack-laravel');
     }
 
     protected function getEncrypter()


### PR DESCRIPTION
Laravel 5.5 introduced a new package auto-discovery feature to make installing Laravel packages easier. By adding extra information in the `composer.json` file, Laravel 5.5+ will identify the listed ServiceProvider and Facade and automatically register them without physically adding them to `config/app.php` in a consuming project.

I also updated the README to describe the new functionality, and modified the `ServiceProviderLaravel5` class to add the `group` string to the `publishes` method.